### PR TITLE
Improve jsdocs

### DIFF
--- a/src/types/int.ts
+++ b/src/types/int.ts
@@ -1,5 +1,9 @@
 import { createType, Type } from '../runtyped'
 
+/**
+ * Integer type creator.
+ * @returns {Type<number>}
+ */
 export const int: Type<number> = createType(
     'int',
     value => {

--- a/src/types/num.ts
+++ b/src/types/num.ts
@@ -1,5 +1,9 @@
 import { createType, Type } from '../runtyped'
 
+/**
+ * Numerical type creator.
+ * @returns {Type<number>}
+ */
 export const num: Type<number> = createType(
     'num',
     value => {

--- a/src/types/opt.ts
+++ b/src/types/opt.ts
@@ -1,5 +1,10 @@
 import { createType, Type, typename } from '../runtyped'
 
+/**
+ * Make `type` optional.
+ * @param {Type<T>} type
+ * @returns {Type<T | undefined>}
+ */
 export const opt = <T>(type: Type<T>) => createType<T | undefined>(
     `opt<${typename(type)}>`,
     value => type.assert(value) || value === undefined,

--- a/src/types/range.ts
+++ b/src/types/range.ts
@@ -1,6 +1,12 @@
 import { extendType, Type } from '../runtyped'
 import { num } from './num'
 
+/**
+ * Discreet numerical range type creator.
+ * @param {number} start Inclusive range start.
+ * @param {number} end Inclusive range end.
+ * @returns {Type<number>}
+ */
 export const range: (start: number, end: number) => Type<number> = (
     start,
     end,

--- a/src/types/shape.ts
+++ b/src/types/shape.ts
@@ -1,5 +1,10 @@
 import { createType, Type, typename } from '../runtyped'
 
+/**
+ * Type creator for an object matching a specific shape.
+ * @param def Object specifying the shape to match.
+ * @returns {Type}
+ */
 export const shape = (def: Record<PropertyKey, Type>) => createType(
     `shape{${Object.entries(def).map(([key, type]) => `${key}:${typename(type)}`)}}`,
     value => !!value

--- a/src/types/str.ts
+++ b/src/types/str.ts
@@ -1,5 +1,9 @@
 import { createType, Type } from '../runtyped'
 
+/**
+ * String type creator.
+ * @returns {Type<string>}
+ */
 export const str: Type<string> = createType(
     'str',
     value => {

--- a/src/types/strf.ts
+++ b/src/types/strf.ts
@@ -1,6 +1,11 @@
 import { extendType, Type } from '../runtyped'
 import { str } from './str'
 
+/**
+ * Formatted string type creator.
+ * @param pattern The string's format.
+ * @returns {Type<String>}
+ */
 export const strf: (pattern: string | RegExp) => Type<string> = pattern => extendType(
     str,
     `strf<${pattern}>`,

--- a/src/types/uint.ts
+++ b/src/types/uint.ts
@@ -1,4 +1,8 @@
 import { int } from './int'
 import { extendType, Type } from '../runtyped'
 
+/**
+ * Unsigned integer type creator.
+ * @returns {Type<number>}
+ */
 export const uint: Type<number> = extendType(int, 'uint', value => value >= 0)


### PR DESCRIPTION
Write jsdocs for the following types:
- `int`
- `num`
- `opt`
- `range`
- `shape`
- `str`
- `strf`
- `uint`